### PR TITLE
Add DotNetHowToSynonyms for synonyms sample code

### DIFF
--- a/DotNetHowToSynonyms/DotNetHowToSynonyms.sln
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetHowToSynonyms", "DotNetHowToSynonyms\DotNetHowToSynonyms.csproj", "{001AB02D-B165-4FB4-808C-48502C69E8BA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms.sln
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetHowToSynonyms", "DotNetHowToSynonyms\DotNetHowToSynonyms.csproj", "{001AB02D-B165-4FB4-808C-48502C69E8BA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetHowToSynonyms", "DotNetHowToSynonyms\DotNetHowToSynonyms.csproj", "{922C9778-230E-489C-9215-DB0C2089D34D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{001AB02D-B165-4FB4-808C-48502C69E8BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{922C9778-230E-489C-9215-DB0C2089D34D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{922C9778-230E-489C-9215-DB0C2089D34D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{922C9778-230E-489C-9215-DB0C2089D34D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{922C9778-230E-489C-9215-DB0C2089D34D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <appSettings>
+    <add key="SearchServiceName" value="Put your search service name here" />
+    <add key="SearchServiceAdminApiKey" value="Put your primary or secondary API key here" />
+    <add key="SearchServiceQueryApiKey" value="Put your query API key here" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.web>
+    <membership defaultProvider="ClientAuthenticationMembershipProvider">
+      <providers>
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+      </providers>
+    </membership>
+    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
+      <providers>
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+      </providers>
+    </roleManager>
+  </system.web>
+</configuration>

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
@@ -4,10 +4,8 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
   <appSettings>
-    <add key="SearchServiceName" value="Put your search service name here" />
-    <add key="SearchServiceAdminApiKey" value="Put your primary or secondary API key here" />
-    <add key="SearchServiceQueryApiKey" value="Put your query API key here" />
-    <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="SearchServiceName" value="[SEARCH SERVICE NAME]" />
+    <add key="SearchServiceApiKey" value="[API KEY]" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -17,16 +15,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <system.web>
-    <membership defaultProvider="ClientAuthenticationMembershipProvider">
-      <providers>
-        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
-      </providers>
-    </membership>
-    <roleManager defaultProvider="ClientRoleProvider" enabled="true">
-      <providers>
-        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
-      </providers>
-    </roleManager>
-  </system.web>
 </configuration>

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/App.config
@@ -4,8 +4,9 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
   <appSettings>
-    <add key="SearchServiceName" value="[SEARCH SERVICE NAME]" />
-    <add key="SearchServiceApiKey" value="[API KEY]" />
+    <add key="SearchServiceName" value="Put your search service name here" />
+    <add key="SearchServiceAdminApiKey" value="Put your primary or secondary API key here" />
+    <add key="SearchServiceQueryApiKey" value="Put your query API key here" />
   </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{001AB02D-B165-4FB4-808C-48502C69E8BA}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AzureSearch.SDKHowTo</RootNamespace>
+    <AssemblyName>AzureSearch.SDKHowTo</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.Search, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.3.0.0-rc\lib\net45\Microsoft.Azure.Search.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.4\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.4\lib\net45\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=6.15.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.6.15.0\lib\portable-net45+win+wpa81\Microsoft.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Hotel.cs" />
+    <Compile Include="Hotel.Methods.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{001AB02D-B165-4FB4-808C-48502C69E8BA}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>AzureSearch.SDKHowTo</RootNamespace>
-    <AssemblyName>AzureSearch.SDKHowTo</AssemblyName>
+    <RootNamespace>AzureSearch.SDKHowToSynonyms</RootNamespace>
+    <AssemblyName>AzureSearch.SDKHowToSynonyms</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{001AB02D-B165-4FB4-808C-48502C69E8BA}</ProjectGuid>
+    <ProjectGuid>{922C9778-230E-489C-9215-DB0C2089D34D}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AzureSearch.SDKHowToSynonyms</RootNamespace>

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/DotNetHowToSynonyms.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Search, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Search.3.0.0-rc\lib\net45\Microsoft.Azure.Search.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Search, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.4.0.0-preview\lib\net45\Microsoft.Azure.Search.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.Methods.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.Methods.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 
-namespace AzureSearch.SDKHowTo
+namespace AzureSearch.SDKHowToSynonyms
 {
     public partial class Hotel
     {

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.Methods.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.Methods.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Text;
+
+namespace AzureSearch.SDKHowTo
+{
+    public partial class Hotel
+    {
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+
+            if (!String.IsNullOrEmpty(HotelId))
+            {
+                builder.AppendFormat("ID: {0}\t", HotelId);
+            }
+
+            if (BaseRate.HasValue)
+            {
+                builder.AppendFormat("Base rate: {0}\t", BaseRate);
+            }
+
+            if (!String.IsNullOrEmpty(Description))
+            {
+                builder.AppendFormat("Description: {0}\t", Description);
+            }
+
+            if (!String.IsNullOrEmpty(DescriptionFr))
+            {
+                builder.AppendFormat("Description (French): {0}\t", DescriptionFr);
+            }
+
+            if (!String.IsNullOrEmpty(HotelName))
+            {
+                builder.AppendFormat("Name: {0}\t", HotelName);
+            }
+
+            if (!String.IsNullOrEmpty(Category))
+            {
+                builder.AppendFormat("Category: {0}\t", Category);
+            }
+
+            if (Tags != null && Tags.Length > 0)
+            {
+                builder.AppendFormat("Tags: [{0}]\t", String.Join(", ", Tags));
+            }
+
+            if (ParkingIncluded.HasValue)
+            {
+                builder.AppendFormat("Parking included: {0}\t", ParkingIncluded.Value ? "yes" : "no");
+            }
+
+            if (SmokingAllowed.HasValue)
+            {
+                builder.AppendFormat("Smoking allowed: {0}\t", SmokingAllowed.Value ? "yes" : "no");
+            }
+
+            if (LastRenovationDate.HasValue)
+            {
+                builder.AppendFormat("Last renovated on: {0}\t", LastRenovationDate);
+            }
+
+            if (Rating.HasValue)
+            {
+                builder.AppendFormat("Rating: {0}/5\t", Rating);
+            }
+
+            if (Location != null)
+            {
+                builder.AppendFormat("Location: Latitude {0}, longitude {1}\t", Location.Latitude, Location.Longitude);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.cs
@@ -5,7 +5,7 @@ using Microsoft.Azure.Search.Models;
 using Microsoft.Spatial;
 using Newtonsoft.Json;
 
-namespace AzureSearch.SDKHowTo
+namespace AzureSearch.SDKHowToSynonyms
 {
     [SerializePropertyNamesAsCamelCase]
     public partial class Hotel

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Hotel.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Spatial;
+using Newtonsoft.Json;
+
+namespace AzureSearch.SDKHowTo
+{
+    [SerializePropertyNamesAsCamelCase]
+    public partial class Hotel
+    {
+        [Key]
+        [IsFilterable]
+        public string HotelId { get; set; }
+
+        [IsFilterable, IsSortable, IsFacetable]
+        public double? BaseRate { get; set; }
+
+        [IsSearchable]
+        public string Description { get; set; }
+
+        [IsSearchable]
+        [Analyzer(AnalyzerName.AsString.FrLucene)]
+        [JsonProperty("description_fr")]
+        public string DescriptionFr { get; set; }
+
+        [IsSearchable, IsFilterable, IsSortable]
+        public string HotelName { get; set; }
+
+        [IsSearchable, IsFilterable, IsSortable, IsFacetable]
+        public string Category { get; set; }
+
+        [IsSearchable, IsFilterable, IsFacetable]
+        public string[] Tags { get; set; }
+
+        [IsFilterable, IsFacetable]
+        public bool? ParkingIncluded { get; set; }
+
+        [IsFilterable, IsFacetable]
+        public bool? SmokingAllowed { get; set; }
+
+        [IsFilterable, IsSortable, IsFacetable]
+        public DateTimeOffset? LastRenovationDate { get; set; }
+
+        [IsFilterable, IsSortable, IsFacetable]
+        public int? Rating { get; set; }
+
+        [IsFilterable, IsSortable]
+        public GeographyPoint Location { get; set; }
+
+        // ToString() method omitted for brevity...
+    }
+}

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
@@ -1,0 +1,275 @@
+﻿#define HowToExample
+
+using System;
+using System.Configuration;
+using System.Linq;
+using System.Threading;
+using Microsoft.Azure.Search;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Spatial;
+
+namespace AzureSearch.SDKHowTo
+{
+    class Program
+    {
+        // This sample shows how to delete, create, upload documents and query an index
+        static void Main(string[] args)
+        {
+            SearchServiceClient serviceClient = CreateSearchServiceClient();
+
+            Console.WriteLine("{0}", "Deleting index...\n");
+            DeleteHotelsIndexIfExists(serviceClient);
+
+            Console.WriteLine("{0}", "Creating index...\n");
+            CreateHotelsIndex(serviceClient);
+
+            ISearchIndexClient indexClient = serviceClient.Indexes.GetClient("hotels");
+
+            Console.WriteLine("{0}", "Uploading documents...\n");
+            UploadDocuments(indexClient);
+
+            ISearchIndexClient indexClientForQueries = CreateSearchIndexClient();
+
+            RunQueries(indexClientForQueries);
+
+            Console.WriteLine("{0}", "Complete.  Press any key to end application...\n");
+            Console.ReadKey();
+        }
+
+        private static SearchServiceClient CreateSearchServiceClient()
+        {
+            string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
+            string adminApiKey = ConfigurationManager.AppSettings["SearchServiceAdminApiKey"];
+
+            SearchServiceClient serviceClient = new SearchServiceClient(searchServiceName, new SearchCredentials(adminApiKey));
+            return serviceClient;
+        }
+
+        private static SearchIndexClient CreateSearchIndexClient()
+        {
+            string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
+            string queryApiKey = ConfigurationManager.AppSettings["SearchServiceQueryApiKey"];
+
+            SearchIndexClient indexClient = new SearchIndexClient(searchServiceName, "hotels", new SearchCredentials(queryApiKey));
+            return indexClient;
+        }
+
+        private static void DeleteHotelsIndexIfExists(SearchServiceClient serviceClient)
+        {
+            if (serviceClient.Indexes.Exists("hotels"))
+            {
+                serviceClient.Indexes.Delete("hotels");
+            }
+        }
+
+        private static void CreateHotelsIndex(SearchServiceClient serviceClient)
+        {
+            var definition = new Index()
+            {
+                Name = "hotels",
+                Fields = FieldBuilder.BuildForType<Hotel>()
+            };
+
+            serviceClient.Indexes.Create(definition);
+        }
+
+#if HowToExample
+
+        private static void UploadDocuments(ISearchIndexClient indexClient)
+        {
+            var hotels = new Hotel[]
+            {
+                new Hotel()
+                { 
+                    HotelId = "1", 
+                    BaseRate = 199.0, 
+                    Description = "Best hotel in town",
+                    DescriptionFr = "Meilleur hôtel en ville",
+                    HotelName = "Fancy Stay",
+                    Category = "Luxury", 
+                    Tags = new[] { "pool", "view", "wifi", "concierge" },
+                    ParkingIncluded = false, 
+                    SmokingAllowed = false,
+                    LastRenovationDate = new DateTimeOffset(2010, 6, 27, 0, 0, 0, TimeSpan.Zero), 
+                    Rating = 5, 
+                    Location = GeographyPoint.Create(47.678581, -122.131577)
+                },
+                new Hotel()
+                { 
+                    HotelId = "2", 
+                    BaseRate = 79.99,
+                    Description = "Cheapest hotel in town",
+                    DescriptionFr = "Hôtel le moins cher en ville",
+                    HotelName = "Roach Motel",
+                    Category = "Budget",
+                    Tags = new[] { "motel", "budget" },
+                    ParkingIncluded = true,
+                    SmokingAllowed = true,
+                    LastRenovationDate = new DateTimeOffset(1982, 4, 28, 0, 0, 0, TimeSpan.Zero),
+                    Rating = 1,
+                    Location = GeographyPoint.Create(49.678581, -122.131577)
+                },
+                new Hotel() 
+                { 
+                    HotelId = "3", 
+                    BaseRate = 129.99,
+                    Description = "Close to town hall and the river"
+                }
+            };
+
+            var batch = IndexBatch.Upload(hotels);
+
+            try
+            {
+                indexClient.Documents.Index(batch);
+            }
+            catch (IndexBatchException e)
+            {
+                // Sometimes when your Search service is under load, indexing will fail for some of the documents in
+                // the batch. Depending on your application, you can take compensating actions like delaying and
+                // retrying. For this simple demo, we just log the failed document keys and continue.
+                Console.WriteLine(
+                    "Failed to index some of the documents: {0}",
+                    String.Join(", ", e.IndexingResults.Where(r => !r.Succeeded).Select(r => r.Key)));
+            }
+
+            Console.WriteLine("Waiting for documents to be indexed...\n");
+            Thread.Sleep(2000);
+        }
+
+#else
+
+        private static void UploadDocuments(ISearchIndexClient indexClient)
+        {
+            var actions =
+                new IndexAction<Hotel>[]
+                {
+                    IndexAction.Upload(
+                        new Hotel()
+                        {
+                            HotelId = "1",
+                            BaseRate = 199.0,
+                            Description = "Best hotel in town",
+                            DescriptionFr = "Meilleur hôtel en ville",
+                            HotelName = "Fancy Stay",
+                            Category = "Luxury",
+                            Tags = new[] { "pool", "view", "wifi", "concierge" },
+                            ParkingIncluded = false,
+                            SmokingAllowed = false,
+                            LastRenovationDate = new DateTimeOffset(2010, 6, 27, 0, 0, 0, TimeSpan.Zero),
+                            Rating = 5,
+                            Location = GeographyPoint.Create(47.678581, -122.131577)
+                        }),
+                    IndexAction.Upload(
+                        new Hotel()
+                        {
+                            HotelId = "2",
+                            BaseRate = 79.99,
+                            Description = "Cheapest hotel in town",
+                            DescriptionFr = "Hôtel le moins cher en ville",
+                            HotelName = "Roach Motel",
+                            Category = "Budget",
+                            Tags = new[] { "motel", "budget" },
+                            ParkingIncluded = true,
+                            SmokingAllowed = true,
+                            LastRenovationDate = new DateTimeOffset(1982, 4, 28, 0, 0, 0, TimeSpan.Zero),
+                            Rating = 1,
+                            Location = GeographyPoint.Create(49.678581, -122.131577)
+                        }),
+                    IndexAction.MergeOrUpload(
+                        new Hotel()
+                        {
+                            HotelId = "3",
+                            BaseRate = 129.99,
+                            Description = "Close to town hall and the river"
+                        }),
+                    IndexAction.Delete(new Hotel() { HotelId = "6" })
+                };
+
+            var batch = IndexBatch.New(actions);
+
+            try
+            {
+                indexClient.Documents.Index(batch);
+            }
+            catch (IndexBatchException e)
+            {
+                // Sometimes when your Search service is under load, indexing will fail for some of the documents in
+                // the batch. Depending on your application, you can take compensating actions like delaying and
+                // retrying. For this simple demo, we just log the failed document keys and continue.
+                Console.WriteLine(
+                    "Failed to index some of the documents: {0}",
+                    String.Join(", ", e.IndexingResults.Where(r => !r.Succeeded).Select(r => r.Key)));
+            }
+
+            Console.WriteLine("Waiting for documents to be indexed...\n");
+            Thread.Sleep(2000);
+        }
+#endif
+
+        private static void RunQueries(ISearchIndexClient indexClient)
+        {
+            SearchParameters parameters;
+            DocumentSearchResult<Hotel> results;
+
+            Console.WriteLine("Search the entire index for the term 'budget' and return only the hotelName field:\n");
+
+            parameters =
+                new SearchParameters()
+                {
+                    Select = new[] { "hotelName" }
+                };
+
+            results = indexClient.Documents.Search<Hotel>("budget", parameters);
+
+            WriteDocuments(results);
+
+            Console.Write("Apply a filter to the index to find hotels cheaper than $150 per night, ");
+            Console.WriteLine("and return the hotelId and description:\n");
+
+            parameters =
+                new SearchParameters()
+                {
+                    Filter = "baseRate lt 150",
+                    Select = new[] { "hotelId", "description" }
+                };
+
+            results = indexClient.Documents.Search<Hotel>("*", parameters);
+
+            WriteDocuments(results);
+
+            Console.Write("Search the entire index, order by a specific field (lastRenovationDate) ");
+            Console.Write("in descending order, take the top two results, and show only hotelName and ");
+            Console.WriteLine("lastRenovationDate:\n");
+
+            parameters =
+                new SearchParameters()
+                {
+                    OrderBy = new[] { "lastRenovationDate desc" },
+                    Select = new[] { "hotelName", "lastRenovationDate" },
+                    Top = 2
+                };
+
+            results = indexClient.Documents.Search<Hotel>("*", parameters);
+
+            WriteDocuments(results);
+
+            Console.WriteLine("Search the entire index for the term 'motel':\n");
+
+            parameters = new SearchParameters();
+            results = indexClient.Documents.Search<Hotel>("motel", parameters);
+
+            WriteDocuments(results);
+        }
+
+        private static void WriteDocuments(DocumentSearchResult<Hotel> searchResults)
+        {
+            foreach (SearchResult<Hotel> result in searchResults.Results)
+            {
+                Console.WriteLine(result.Document);
+            }
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
@@ -12,13 +12,13 @@ namespace AzureSearch.SDKHowToSynonyms
 {
     class Program
     {
-        // This sample shows how to delete, create, upload documents and query an index
+        // This sample shows how to delete, create, upload documents and query an index with a synonym map
         static void Main(string[] args)
         {
             SearchServiceClient serviceClient = CreateSearchServiceClient();
 
-            Console.WriteLine("{0}", "Deleting index...\n");
-            DeleteHotelsIndexIfExists(serviceClient);
+            Console.WriteLine("{0}", "Cleaning up resources...\n");
+            CleanupResources(serviceClient);
 
             Console.WriteLine("{0}", "Creating index...\n");
             CreateHotelsIndex(serviceClient);
@@ -29,8 +29,6 @@ namespace AzureSearch.SDKHowToSynonyms
             UploadDocuments(indexClient);
 
             ISearchIndexClient indexClientForQueries = CreateSearchIndexClient();
-
-            RunQueries(indexClientForQueries);
 
             RunQueriesWithNonExistentTermsInIndex(indexClientForQueries);
 
@@ -49,7 +47,7 @@ namespace AzureSearch.SDKHowToSynonyms
         private static SearchServiceClient CreateSearchServiceClient()
         {
             string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
-            string adminApiKey = ConfigurationManager.AppSettings["SearchServiceAdminApiKey"];
+            string adminApiKey = ConfigurationManager.AppSettings["SearchServiceApiKey"];
 
             SearchServiceClient serviceClient = new SearchServiceClient(searchServiceName, new SearchCredentials(adminApiKey));
             return serviceClient;
@@ -58,13 +56,13 @@ namespace AzureSearch.SDKHowToSynonyms
         private static SearchIndexClient CreateSearchIndexClient()
         {
             string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
-            string queryApiKey = ConfigurationManager.AppSettings["SearchServiceQueryApiKey"];
+            string queryApiKey = ConfigurationManager.AppSettings["SearchServiceApiKey"];
 
             SearchIndexClient indexClient = new SearchIndexClient(searchServiceName, "hotels", new SearchCredentials(queryApiKey));
             return indexClient;
         }
 
-        private static void DeleteHotelsIndexIfExists(SearchServiceClient serviceClient)
+        private static void CleanupResources(SearchServiceClient serviceClient)
         {
             if (serviceClient.Indexes.Exists("hotels"))
             {
@@ -96,8 +94,6 @@ namespace AzureSearch.SDKHowToSynonyms
 
             serviceClient.Indexes.CreateOrUpdate(index);
         }
-
-#if HowToExample
 
         private static void UploadSynonyms(SearchServiceClient serviceClient)
         {
@@ -173,131 +169,6 @@ namespace AzureSearch.SDKHowToSynonyms
             Thread.Sleep(2000);
         }
 
-#else
-
-        private static void UploadDocuments(ISearchIndexClient indexClient)
-        {
-            var actions =
-                new IndexAction<Hotel>[]
-                {
-                    IndexAction.Upload(
-                        new Hotel()
-                        {
-                            HotelId = "1",
-                            BaseRate = 199.0,
-                            Description = "Best hotel in town",
-                            DescriptionFr = "Meilleur hôtel en ville",
-                            HotelName = "Fancy Stay",
-                            Category = "Luxury",
-                            Tags = new[] { "pool", "view", "wifi", "concierge" },
-                            ParkingIncluded = false,
-                            SmokingAllowed = false,
-                            LastRenovationDate = new DateTimeOffset(2010, 6, 27, 0, 0, 0, TimeSpan.Zero),
-                            Rating = 5,
-                            Location = GeographyPoint.Create(47.678581, -122.131577)
-                        }),
-                    IndexAction.Upload(
-                        new Hotel()
-                        {
-                            HotelId = "2",
-                            BaseRate = 79.99,
-                            Description = "Cheapest hotel in town",
-                            DescriptionFr = "Hôtel le moins cher en ville",
-                            HotelName = "Roach Motel",
-                            Category = "Budget",
-                            Tags = new[] { "motel", "budget" },
-                            ParkingIncluded = true,
-                            SmokingAllowed = true,
-                            LastRenovationDate = new DateTimeOffset(1982, 4, 28, 0, 0, 0, TimeSpan.Zero),
-                            Rating = 1,
-                            Location = GeographyPoint.Create(49.678581, -122.131577)
-                        }),
-                    IndexAction.MergeOrUpload(
-                        new Hotel()
-                        {
-                            HotelId = "3",
-                            BaseRate = 129.99,
-                            Description = "Close to town hall and the river"
-                        }),
-                    IndexAction.Delete(new Hotel() { HotelId = "6" })
-                };
-
-            var batch = IndexBatch.New(actions);
-
-            try
-            {
-                indexClient.Documents.Index(batch);
-            }
-            catch (IndexBatchException e)
-            {
-                // Sometimes when your Search service is under load, indexing will fail for some of the documents in
-                // the batch. Depending on your application, you can take compensating actions like delaying and
-                // retrying. For this simple demo, we just log the failed document keys and continue.
-                Console.WriteLine(
-                    "Failed to index some of the documents: {0}",
-                    String.Join(", ", e.IndexingResults.Where(r => !r.Succeeded).Select(r => r.Key)));
-            }
-
-            Console.WriteLine("Waiting for documents to be indexed...\n");
-            Thread.Sleep(2000);
-        }
-#endif
-
-        private static void RunQueries(ISearchIndexClient indexClient)
-        {
-            SearchParameters parameters;
-            DocumentSearchResult<Hotel> results;
-
-            Console.WriteLine("Search the entire index for the term 'budget' and return only the hotelName field:\n");
-
-            parameters =
-                new SearchParameters()
-                {
-                    Select = new[] { "hotelName" }
-                };
-
-            results = indexClient.Documents.Search<Hotel>("budget", parameters);
-
-            WriteDocuments(results);
-
-            Console.Write("Apply a filter to the index to find hotels cheaper than $150 per night, ");
-            Console.WriteLine("and return the hotelId and description:\n");
-
-            parameters =
-                new SearchParameters()
-                {
-                    Filter = "baseRate lt 150",
-                    Select = new[] { "hotelId", "description" }
-                };
-
-            results = indexClient.Documents.Search<Hotel>("*", parameters);
-
-            WriteDocuments(results);
-
-            Console.Write("Search the entire index, order by a specific field (lastRenovationDate) ");
-            Console.Write("in descending order, take the top two results, and show only hotelName and ");
-            Console.WriteLine("lastRenovationDate:\n");
-
-            parameters =
-                new SearchParameters()
-                {
-                    OrderBy = new[] { "lastRenovationDate desc" },
-                    Select = new[] { "hotelName", "lastRenovationDate" },
-                    Top = 2
-                };
-
-            results = indexClient.Documents.Search<Hotel>("*", parameters);
-
-            WriteDocuments(results);
-
-            Console.WriteLine("Search the entire index for the term 'motel':\n");
-
-            parameters = new SearchParameters();
-            results = indexClient.Documents.Search<Hotel>("motel", parameters);
-
-            WriteDocuments(results);
-        }
-
         private static void RunQueriesWithNonExistentTermsInIndex(ISearchIndexClient indexClient)
         {
             SearchParameters parameters;
@@ -316,12 +187,12 @@ namespace AzureSearch.SDKHowToSynonyms
             results = indexClient.Documents.Search<Hotel>("\"five star\"", parameters);
             WriteDocuments(results);
 
-            Console.WriteLine("Search the entire index for the terms 'economy' and 'hotel':\n");
-            results = indexClient.Documents.Search<Hotel>("economy hotel", parameters);
-            WriteDocuments(results);
-
             Console.WriteLine("Search the entire index for the term 'internet':\n");
             results = indexClient.Documents.Search<Hotel>("internet", parameters);
+            WriteDocuments(results);
+
+            Console.WriteLine("Search the entire index for the terms 'economy' AND 'hotel':\n");
+            results = indexClient.Documents.Search<Hotel>("economy hotel", parameters);
             WriteDocuments(results);
         }
 

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.Azure.Search;
 using Microsoft.Azure.Search.Models;
 using Microsoft.Spatial;
 
-namespace AzureSearch.SDKHowTo
+namespace AzureSearch.SDKHowToSynonyms
 {
     class Program
     {

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
@@ -47,7 +47,7 @@ namespace AzureSearch.SDKHowToSynonyms
         private static SearchServiceClient CreateSearchServiceClient()
         {
             string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
-            string adminApiKey = ConfigurationManager.AppSettings["SearchServiceApiKey"];
+            string adminApiKey = ConfigurationManager.AppSettings["SearchServiceAdminApiKey"];
 
             SearchServiceClient serviceClient = new SearchServiceClient(searchServiceName, new SearchCredentials(adminApiKey));
             return serviceClient;
@@ -56,7 +56,7 @@ namespace AzureSearch.SDKHowToSynonyms
         private static SearchIndexClient CreateSearchIndexClient()
         {
             string searchServiceName = ConfigurationManager.AppSettings["SearchServiceName"];
-            string queryApiKey = ConfigurationManager.AppSettings["SearchServiceApiKey"];
+            string queryApiKey = ConfigurationManager.AppSettings["SearchServiceQueryApiKey"];
 
             SearchIndexClient indexClient = new SearchIndexClient(searchServiceName, "hotels", new SearchCredentials(queryApiKey));
             return indexClient;
@@ -192,7 +192,7 @@ namespace AzureSearch.SDKHowToSynonyms
             WriteDocuments(results);
 
             Console.WriteLine("Search the entire index for the terms 'economy' AND 'hotel':\n");
-            results = indexClient.Documents.Search<Hotel>("economy hotel", parameters);
+            results = indexClient.Documents.Search<Hotel>("economy AND hotel", parameters);
             WriteDocuments(results);
         }
 

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Properties/AssemblyInfo.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AzureSearch.DotNetHowTo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AzureSearch.DotNetHowTo")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b202792-2c3e-4c96-ba29-fe449805526c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Properties/AssemblyInfo.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("AzureSearch.DotNetHowTo")]
+[assembly: AssemblyTitle("AzureSearch.DotNetHowToSynonyms")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("AzureSearch.DotNetHowTo")]
+[assembly: AssemblyProduct("AzureSearch.DotNetHowToSynonyms")]
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/packages.config
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.Search" version="3.0.0-rc" targetFramework="net45" />
+  <package id="Microsoft.Azure.Search" version="4.0.0-preview" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.4" targetFramework="net45" />
   <package id="Microsoft.Spatial" version="6.15.0" targetFramework="net45" />

--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/packages.config
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.Search" version="3.0.0-rc" targetFramework="net45" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net45" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.4" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="6.15.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
DotNetHowToSynonyms is a clone of DotNetHowTo with code samples for synonyms. 
This doesn't build; we need the 4.x version of SDK and update the reference in packages.config.
@brjohnstmsft, @chaosrealm, @HeidiSteen, @Yahnoosh