### PR TITLE
Putting usings inside namespaces to make it easier to include in docs

### DIFF
--- a/DotNetHowTo/DotNetHowTo/Hotel.Methods.cs
+++ b/DotNetHowTo/DotNetHowTo/Hotel.Methods.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Text;
-
-namespace AzureSearch.SDKHowTo
+﻿namespace AzureSearch.SDKHowTo
 {
+    using System;
+    using System.Text;
+
     public partial class Hotel
     {
         // This implementation of ToString() is only for the purposes of the sample console application.

--- a/DotNetHowTo/DotNetHowTo/Hotel.cs
+++ b/DotNetHowTo/DotNetHowTo/Hotel.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
-using Microsoft.Spatial;
-using Newtonsoft.Json;
-
-namespace AzureSearch.SDKHowTo
+﻿namespace AzureSearch.SDKHowTo
 {
+    using System;
+    using Microsoft.Azure.Search;
+    using Microsoft.Azure.Search.Models;
+    using Microsoft.Spatial;
+    using Newtonsoft.Json;
+
     // The SerializePropertyNamesAsCamelCase attribute is defined in the Azure Search .NET SDK.
     // It ensures that Pascal-case property names in the model class are mapped to camel-case
     // field names in the index.

--- a/DotNetHowTo/DotNetHowTo/Program.cs
+++ b/DotNetHowTo/DotNetHowTo/Program.cs
@@ -1,15 +1,15 @@
 ﻿#define HowToExample
 
-using System;
-using System.Linq;
-using System.Threading;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Spatial;
-
 namespace AzureSearch.SDKHowTo
 {
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using Microsoft.Azure.Search;
+    using Microsoft.Azure.Search.Models;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Spatial;
+
     class Program
     {
         // This sample shows how to delete, create, upload documents and query an index


### PR DESCRIPTION
Feedback from readers indicates that it is sometimes difficult to tell which namespace certain parts of the SDK belong to. This change puts the using directives inside the namespace declarations so that it's easier to include them as extra context in the articles.