### PR TITLE
Update DotNetHowTo to .NET Core 2.0 and fixing serialization binder e…

### DIFF
--- a/DotNetHowTo/DotNetHowTo/DotNetHowTo.csproj
+++ b/DotNetHowTo/DotNetHowTo/DotNetHowTo.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Search" Version="3.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0-preview1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="3.3.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…xception

The workaround for the serialization binder exception is to use Microsoft.Rest.ClientRuntime.Azure 3.3.8 or later.

This fixes https://github.com/Azure-Samples/search-dotnet-getting-started/issues/22