### PR TITLE
Update Autocomplete sample to run against latest Search SDK, 10.1

### DIFF
--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Controllers/HomeController.cs
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Controllers/HomeController.cs
@@ -55,7 +55,7 @@ namespace AutocompleteTutorial.Controllers
                 sp.HighlightPostTag = "</b>";
             }
 
-            DocumentSuggestResult suggestResult = _indexClient.Documents.Suggest(term, "sg",sp);
+            DocumentSuggestResult<Document> suggestResult = _indexClient.Documents.Suggest(term, "sg",sp);
 
             // Convert the suggest query results to a list that can be displayed in the client.
             List<string> suggestions = suggestResult.Results.Select(x => x.Text).ToList();
@@ -99,7 +99,7 @@ namespace AutocompleteTutorial.Controllers
             };
 
 
-            DocumentSearchResult searchResult = _indexClient.Documents.Search("*", sp);
+            DocumentSearchResult<Document> searchResult = _indexClient.Documents.Search("*", sp);
 
             // Convert the suggest query results to a list that can be displayed in the client.
 

--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/DotNetHowToAutocomplete.csproj
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/DotNetHowToAutocomplete.csproj
@@ -46,39 +46,40 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Azure.Search, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Search.6.0.0-preview\lib\net452\Microsoft.Azure.Search.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Search, Version=10.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.10.1.0\lib\net461\Microsoft.Azure.Search.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Search.Common, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Search.Common.6.0.0-preview\lib\net452\Microsoft.Azure.Search.Common.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Search.Common, Version=10.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.Common.10.1.0\lib\net461\Microsoft.Azure.Search.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Search.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Search.Data.6.0.0-preview\lib\net452\Microsoft.Azure.Search.Data.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Search.Data, Version=10.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.Data.10.1.0\lib\net461\Microsoft.Azure.Search.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.Search.Service, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.Search.Service.6.0.0-preview\lib\net452\Microsoft.Azure.Search.Service.dll</HintPath>
+    <Reference Include="Microsoft.Azure.Search.Service, Version=10.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.Search.Service.10.1.0\lib\net461\Microsoft.Azure.Search.Service.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.11\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.20\lib\net461\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime.Azure, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.12\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Rest.ClientRuntime.Azure.3.3.18\lib\net452\Microsoft.Rest.ClientRuntime.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.5.3.21218, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.5.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />

--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Web.config
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Web.config
@@ -22,7 +22,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Web.config
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/Web.config
@@ -51,7 +51,7 @@
   </system.webServer>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:5 /nowarn:1659;1699;1701" />
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>

--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/packages.config
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net461" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net461" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net461" />
   <package id="jQuery" version="1.10.2" targetFramework="net461" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net461" />

--- a/DotNetHowToAutocomplete/DotNetHowToAutocomplete/packages.config
+++ b/DotNetHowToAutocomplete/DotNetHowToAutocomplete/packages.config
@@ -15,19 +15,19 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
-  <package id="Microsoft.Azure.Search" version="6.0.0-preview" targetFramework="net461" />
-  <package id="Microsoft.Azure.Search.Common" version="6.0.0-preview" targetFramework="net461" />
-  <package id="Microsoft.Azure.Search.Data" version="6.0.0-preview" targetFramework="net461" />
-  <package id="Microsoft.Azure.Search.Service" version="6.0.0-preview" targetFramework="net461" />
+  <package id="Microsoft.Azure.Search" version="10.1.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.Search.Common" version="10.1.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.Search.Data" version="10.1.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.Search.Service" version="10.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net461" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Net.Compilers" version="2.4.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.Rest.ClientRuntime" version="2.3.11" targetFramework="net461" />
-  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.12" targetFramework="net461" />
-  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net461" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net461" />
+  <package id="Microsoft.Rest.ClientRuntime.Azure" version="3.3.18" targetFramework="net461" />
+  <package id="Microsoft.Spatial" version="7.5.3" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.6.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="Respond" version="1.2.0" targetFramework="net461" />
   <package id="WebGrease" version="1.5.2" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Looks like the packages file didn't get updated when I did this last year.  Have no idea why.  Verified this runs on a  clean machine with VS 2019 and Chrome 79.0.3945.117