### PR TITLE
Remove "Format" property in SynonymMap constructor

### DIFF
--- a/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
+++ b/DotNetHowToSynonyms/DotNetHowToSynonyms/Program.cs
@@ -123,7 +123,6 @@ namespace AzureSearch.SDKHowToSynonyms
             var synonymMap = new SynonymMap()
             {
                 Name = "desc-synonymmap",
-                Format = "solr",
                 Synonyms = "hotel, motel\ninternet,wifi\nfive star=>luxury\neconomy,inexpensive=>budget"
             };
 


### PR DESCRIPTION
I recently updated the NuGet packages in the project and it looks like SynonymMap now has a static "Format" property so attempting to use this static property in the constructor, as shown in the sample code here, will result in a compilation error "Static field or property 'SynonymMap.Format' cannot be assigned in an object initializer". This property has "solr" assigned to it as its default value anyway so removing it from the constructor ensures we get a successful build.